### PR TITLE
Add whisk dev-friendly API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ ark-ec ="^0.3.0"
 ark-ff ="^0.3.0"
 ark-bls12-381 = "^0.3.0"
 ark-std ="^0.3.0"
-ark-serialize = "^0.3.0"
+ark-serialize = { version = "^0.3.0", features = ["derive"] }
 thiserror = "1.0.32"
 hashbrown = "0.12.3"
 

--- a/src/commitments.rs
+++ b/src/commitments.rs
@@ -23,13 +23,14 @@
 
 use ark_bls12_381::{Fr, G1Projective};
 use ark_ec::group::Group;
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, Read, SerializationError, Write};
 
 use std::ops::{Add, Mul};
 
 /// A GroupCommitment object
 ///
 /// $GroupCommitment((G , H); T ; r ) = cm_T = (cm_{T,1} , cm_{T,2} ) = (r G , T + r H)$
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, CanonicalDeserialize, CanonicalSerialize, Debug, PartialEq, Eq)]
 pub struct GroupCommitment {
     /// Given $GroupCommitment((G , H); T ; r )$ this is $rG$
     pub T_1: G1Projective,

--- a/src/curdleproofs.rs
+++ b/src/curdleproofs.rs
@@ -1,6 +1,5 @@
 #![allow(non_snake_case)]
-use ark_bls12_381::Fr;
-pub use ark_bls12_381::{G1Affine, G1Projective};
+pub use ark_bls12_381::{Fr, G1Affine, G1Projective};
 use ark_ec::ProjectiveCurve;
 use ark_ff::PrimeField;
 pub use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, SerializationError};

--- a/src/curdleproofs.rs
+++ b/src/curdleproofs.rs
@@ -1,8 +1,10 @@
 #![allow(non_snake_case)]
-use ark_bls12_381::{Fr, G1Affine, G1Projective};
+use ark_bls12_381::Fr;
+pub use ark_bls12_381::{G1Affine, G1Projective};
 use ark_ec::ProjectiveCurve;
 use ark_ff::PrimeField;
-use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, Read, SerializationError, Write};
+pub use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, SerializationError};
+use ark_serialize::{Read, Write};
 use ark_std::rand::RngCore;
 use ark_std::rand::{rngs::StdRng, SeedableRng};
 use ark_std::{UniformRand, Zero};

--- a/src/curdleproofs.rs
+++ b/src/curdleproofs.rs
@@ -2,6 +2,7 @@
 use ark_bls12_381::{Fr, G1Affine, G1Projective};
 use ark_ec::ProjectiveCurve;
 use ark_ff::PrimeField;
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, Read, SerializationError, Write};
 use ark_std::rand::RngCore;
 use ark_std::rand::{rngs::StdRng, SeedableRng};
 use ark_std::{UniformRand, Zero};
@@ -21,7 +22,7 @@ use crate::same_scalar_argument::SameScalarProof;
 use crate::N_BLINDERS;
 
 /// The Curdleproofs CRS
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, CanonicalSerialize, CanonicalDeserialize)]
 pub struct CurdleproofsCrs {
     /// Pedersen commitment bases
     pub vec_G: Vec<G1Affine>,
@@ -67,7 +68,7 @@ pub fn generate_crs(ell: usize) -> CurdleproofsCrs {
 }
 
 /// A Curdleproofs proof object
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, CanonicalSerialize, CanonicalDeserialize)]
 pub struct CurdleproofsProof {
     A: G1Projective,
     cm_T: GroupCommitment,

--- a/src/grand_product_argument.rs
+++ b/src/grand_product_argument.rs
@@ -4,6 +4,7 @@ use core::iter;
 use ark_bls12_381::{Fr, G1Affine, G1Projective};
 use ark_ec::{AffineCurve, ProjectiveCurve};
 use ark_ff::{Field, One};
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, Read, SerializationError, Write};
 use ark_std::rand::RngCore;
 use ark_std::Zero;
 
@@ -16,7 +17,7 @@ use crate::msm_accumulator::MsmAccumulator;
 use crate::util::{generate_blinders, inner_product, msm};
 
 /// A GrandProduct proof object
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, CanonicalSerialize, CanonicalDeserialize)]
 pub struct GrandProductProof {
     C: G1Projective,
 

--- a/src/inner_product_argument.rs
+++ b/src/inner_product_argument.rs
@@ -4,6 +4,7 @@ use ark_ec::AffineCurve;
 use ark_ec::ProjectiveCurve;
 use ark_ff::PrimeField;
 use ark_ff::{batch_inversion, Field};
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, Read, SerializationError, Write};
 use ark_std::rand::RngCore;
 use ark_std::{One, Zero};
 
@@ -17,7 +18,7 @@ use crate::util::{
 };
 
 /// An IPA proof object
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, CanonicalSerialize, CanonicalDeserialize)]
 pub struct InnerProductProof {
     B_c: G1Projective,
     B_d: G1Projective,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,9 @@ pub mod same_scalar_argument;
 pub mod transcript;
 pub mod util;
 
+// To use in whisk code
+pub use ark_bls12_381::g1::G1_GENERATOR_X;
+
 #[doc = include_str!("../doc/notes.md")]
 pub mod notes {
     #[doc = include_str!("../doc/optimizations.md")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub mod same_permutation_argument;
 pub mod same_scalar_argument;
 pub mod transcript;
 pub mod util;
+pub mod whisk;
 
 // To use in whisk code
 pub use ark_bls12_381::g1::G1_GENERATOR_X;

--- a/src/same_multiscalar_argument.rs
+++ b/src/same_multiscalar_argument.rs
@@ -4,6 +4,7 @@ use ark_ec::AffineCurve;
 use ark_ec::ProjectiveCurve;
 use ark_ff::PrimeField;
 use ark_ff::{batch_inversion, Field, One};
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, Read, SerializationError, Write};
 use ark_std::rand::RngCore;
 
 use crate::transcript::CurdleproofsTranscript;
@@ -16,7 +17,7 @@ use crate::util::{
 };
 
 /// A $SameMsm$ proof object
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, CanonicalSerialize, CanonicalDeserialize)]
 pub struct SameMultiscalarProof {
     B_a: G1Projective,
     B_t: G1Projective,

--- a/src/same_permutation_argument.rs
+++ b/src/same_permutation_argument.rs
@@ -5,6 +5,7 @@ use ark_bls12_381::{Fr, G1Affine, G1Projective};
 use ark_ec::group::Group;
 use ark_ec::ProjectiveCurve;
 use ark_ff::PrimeField;
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, Read, SerializationError, Write};
 use ark_std::rand::RngCore;
 
 use crate::transcript::CurdleproofsTranscript;
@@ -16,7 +17,7 @@ use crate::msm_accumulator::MsmAccumulator;
 use crate::util::{get_permutation, msm};
 
 /// A same permutation proof object
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, CanonicalSerialize, CanonicalDeserialize)]
 pub struct SamePermutationProof {
     B: G1Projective,
 

--- a/src/same_scalar_argument.rs
+++ b/src/same_scalar_argument.rs
@@ -3,6 +3,7 @@
 use ark_bls12_381::{Fr, G1Projective};
 use ark_ec::ProjectiveCurve;
 use ark_ff::PrimeField;
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, Read, SerializationError, Write};
 use ark_std::rand::RngCore;
 use ark_std::UniformRand;
 
@@ -11,7 +12,7 @@ use crate::errors::ProofError;
 use crate::transcript::CurdleproofsTranscript;
 use merlin::Transcript;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, CanonicalSerialize, CanonicalDeserialize)]
 pub struct SameScalarProof {
     cm_A: GroupCommitment,
     cm_B: GroupCommitment,

--- a/src/whisk.rs
+++ b/src/whisk.rs
@@ -1,43 +1,47 @@
 #![allow(non_snake_case)]
-use ark_bls12_381::{Fr, G1Affine, G1Projective};
+pub use ark_bls12_381::g1::G1_GENERATOR_X;
+pub use ark_bls12_381::{Fr, G1Affine, G1Projective};
+use ark_ec::AffineCurve;
+use ark_ff::{PrimeField, ToBytes};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, Read, SerializationError, Write};
 use ark_std::rand::prelude::SliceRandom;
 use ark_std::rand::RngCore;
 use ark_std::UniformRand;
+use merlin::Transcript;
 use std::io::Cursor;
 
 use crate::{
     curdleproofs::{CurdleproofsCrs, CurdleproofsProof},
+    transcript::CurdleproofsTranscript,
     util::shuffle_permute_and_commit_input,
     N_BLINDERS,
 };
 
-const G1POINT_SIZE: usize = 48;
-const SHUFFLE_PROOF_SIZE: usize = 1024;
-const TRACKER_PROOF_SIZE: usize = 1024;
+pub const FIELD_ELEMENT_SIZE: usize = 32;
+pub const G1POINT_SIZE: usize = 48;
+pub const SHUFFLE_PROOF_SIZE: usize = 32768;
+pub const TRACKER_PROOF_SIZE: usize = 1024;
 
 // TODO: Customize
-const N: usize = 64;
+const N: usize = 128;
 const ELL: usize = N - N_BLINDERS;
 
-pub type G1PointBytes = [u8; G1POINT_SIZE];
 pub type ShuffleProofBytes = [u8; SHUFFLE_PROOF_SIZE];
 pub type TrackerProofBytes = [u8; TRACKER_PROOF_SIZE];
+pub type FieldElementBytes = [u8; FIELD_ELEMENT_SIZE];
 
+#[derive(Clone, Debug)]
 pub struct WhiskTracker {
-    pub r_g: G1PointBytes,   // r * G
-    pub k_r_g: G1PointBytes, // k * r * G
+    pub r_G: G1Affine,   // r * G
+    pub k_r_G: G1Affine, // k * r * G
 }
 
 /// A tracker proof object
 #[derive(Clone, Debug, CanonicalSerialize, CanonicalDeserialize)]
 pub struct TrackerProof {
-    k_G: G1Projective,
-    // TODO: Is the generator necessary to include in the proof?
-    G: G1Projective,
     A: G1Projective,
     B: G1Projective,
-    s: G1Projective,
+    s: Fr,
 }
 
 /// Verify a whisk shuffle proof
@@ -54,17 +58,17 @@ pub fn is_valid_whisk_shuffle_proof<T: RngCore>(
     crs: &CurdleproofsCrs,
     pre_trackers: &Vec<WhiskTracker>,
     post_trackers: &Vec<WhiskTracker>,
-    m: &G1PointBytes,
+    m: &G1Affine,
     shuffle_proof: &ShuffleProofBytes,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let (vec_r, vec_s) = deserialize_trackers(pre_trackers)?;
-    let (vec_t, vec_u) = deserialize_trackers(post_trackers)?;
-    let m_projective = G1Projective::from(deserialize_g1_point(m)?);
+) -> Result<bool, SerializationError> {
+    let (vec_r, vec_s) = unzip_trackers(pre_trackers);
+    let (vec_t, vec_u) = unzip_trackers(post_trackers);
+    let m_projective = G1Projective::from(*m);
     let shuffle_proof_instance = deserialize_shuffle_proof(shuffle_proof)?;
 
-    shuffle_proof_instance.verify(crs, &vec_r, &vec_s, &vec_t, &vec_u, &m_projective, rng)?;
-
-    Ok(())
+    Ok(shuffle_proof_instance
+        .verify(crs, &vec_r, &vec_s, &vec_t, &vec_u, &m_projective, rng)
+        .is_ok())
 }
 
 /// Create a whisk shuffle proof and serialize it for Whisk
@@ -84,7 +88,7 @@ pub fn generate_whisk_shuffle_proof<T: RngCore>(
     rng: &mut T,
     crs: &CurdleproofsCrs,
     pre_trackers: &Vec<WhiskTracker>,
-) -> Result<(Vec<WhiskTracker>, G1PointBytes, ShuffleProofBytes), Box<dyn std::error::Error>> {
+) -> Result<(Vec<WhiskTracker>, G1Affine, ShuffleProofBytes), SerializationError> {
     // Get witnesses: the permutation, the randomizer, and a bunch of blinders
     let mut permutation: Vec<u32> = (0..ELL as u32).collect();
 
@@ -93,7 +97,7 @@ pub fn generate_whisk_shuffle_proof<T: RngCore>(
     let k = Fr::rand(rng);
 
     // Get shuffle inputs
-    let (vec_r, vec_s) = deserialize_trackers(pre_trackers)?;
+    let (vec_r, vec_s) = unzip_trackers(pre_trackers);
 
     let (vec_t, vec_u, m, vec_m_blinders) =
         shuffle_permute_and_commit_input(crs, &vec_r, &vec_s, &permutation, &k, rng);
@@ -115,8 +119,8 @@ pub fn generate_whisk_shuffle_proof<T: RngCore>(
     shuffle_proof_instance.serialize(&mut shuffle_proof)?;
 
     Ok((
-        serialize_trackers(&vec_t, &vec_u)?,
-        serialize_g1_point(&G1Affine::from(m))?,
+        zip_trackers(&vec_t, &vec_u),
+        G1Affine::from(m),
         serialize_shuffle_proof(&shuffle_proof_instance)?,
     ))
 }
@@ -124,105 +128,107 @@ pub fn generate_whisk_shuffle_proof<T: RngCore>(
 /// Verify knowledge of `k` such that `tracker.k_r_g == k * tracker.r_g` and `k_commitment == k * BLS_G1_GENERATOR`.
 /// Defined in https://github.com/nalinbhardwaj/curdleproofs.pie/blob/59eb1d54fe193f063a718fc3bdded4734e66bddc/curdleproofs/curdleproofs/whisk_interface.py#L48-L68
 pub fn is_valid_whisk_tracker_proof(
-    crs: &CurdleproofsCrs,
     tracker: &WhiskTracker,
-    k_commitment: &G1PointBytes,
+    k_commitment: &G1Affine,
     tracker_proof: &TrackerProofBytes,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<bool, SerializationError> {
     let tracker_proof = deserialize_tracker_proof(tracker_proof)?;
+
+    // TODO: deserializing here to serialize immediately after in append_list()
+    //       serde could be avoided but there's value in checking point's ok before proof gen
+    let k_r_G = &tracker.k_r_G;
+    let r_G = &tracker.r_G;
+    let k_G = &k_commitment;
+    let G = G1Affine::prime_subgroup_generator();
 
     // `k_r_G`: Existing WhiskTracker.k_r_g
     // `r_G`: Existing WhiskTracker.k_r_g
-    // `k_G`: ?? provided externally, k commitment?
-    // `G`: Generator point, known by all not necessary
-    // `A`: From python implementation `A = multiply(G, int(blinder))`
-    // `B`: From python implementation `B = multiply(r_G, int(blinder))`
-    // `s`: From python implementation `s = blinder - challenge * k`
+    // `k_G`: Existing k commitment
+    // `G`: Generator point, omit as is public knowledge
+    // `A`: From py impl `A = multiply(G, int(blinder))`
+    // `B`: From py impl `B = multiply(r_G, int(blinder))`
+    // `s`: From py impl `s = blinder - challenge * k`
 
-    // challenge = transcript.get_and_append_challenge(
-    //     b"tracker_opening_proof_challenge"
-    // )
-    //
-    // Aprime = add(multiply(self.G, int(self.s)), multiply(self.k_G, int(challenge)))
-    // Bprime = add(
-    //     multiply(self.r_G, int(self.s)), multiply(self.k_r_G, int(challenge))
-    // )
-    //
-    // return eq(Aprime, self.A) and eq(Bprime, self.B)
+    let mut transcript = Transcript::new(b"whisk_opening_proof");
 
-    todo!("wisk");
+    // TODO: Check points before creating proof?
+    transcript.append_list(
+        b"tracker_opening_proof",
+        [
+            &k_G,
+            &G1Affine::prime_subgroup_generator(),
+            &k_r_G,
+            &r_G,
+            &G1Affine::from(tracker_proof.A),
+            &G1Affine::from(tracker_proof.B),
+        ]
+        .as_slice(),
+    );
+    let challenge = transcript.get_and_append_challenge(b"tracker_opening_proof_challenge");
+
+    let A_prime = G.mul(tracker_proof.s) + k_G.mul(challenge);
+    let B_prime = r_G.mul(tracker_proof.s) + k_r_G.mul(challenge);
+
+    Ok(A_prime == tracker_proof.A && B_prime == tracker_proof.B)
 }
 
-pub fn generate_whisk_tracker_proof(
-    crs: &CurdleproofsCrs,
+pub fn generate_whisk_tracker_proof<T: RngCore>(
+    rng: &mut T,
     tracker: &WhiskTracker,
-    k_G: G1Projective,
-    G: G1Projective,
-    k: Fr,
-) -> Result<TrackerProofBytes, Box<dyn std::error::Error>> {
-    let k_r_g = tracker.k_r_g;
-    let r_g = tracker.r_g;
+    k_commitment: &G1Affine,
+    k: &Fr,
+) -> Result<TrackerProofBytes, SerializationError> {
+    let k_r_g = tracker.k_r_G;
+    let r_g = tracker.r_G;
+    let k_G = k_commitment;
+    let G = G1Affine::prime_subgroup_generator();
 
-    // blinder = generate_blinders(1)[0]
-    // A = multiply(G, int(blinder))
-    // B = multiply(r_G, int(blinder))
+    let blinder = Fr::rand(rng);
+    let A = G.mul(blinder);
+    let B = r_g.mul(blinder);
 
-    // transcript.append_list(
-    //     b"tracker_opening_proof",
-    //     points_projective_to_bytes([k_G, G, k_r_G, r_G, A, B]),
-    // )
+    let mut transcript = Transcript::new(b"whisk_opening_proof");
 
-    // challenge = transcript.get_and_append_challenge(
-    //     b"tracker_opening_proof_challenge"
-    // )
-    // s = blinder - challenge * k
+    transcript.append_list(
+        b"tracker_opening_proof",
+        [
+            &k_G,
+            &G,
+            &k_r_g,
+            &r_g,
+            &G1Affine::from(A),
+            &G1Affine::from(B),
+        ]
+        .as_slice(),
+    );
 
-    todo!("whisk");
+    let challenge = transcript.get_and_append_challenge(b"tracker_opening_proof_challenge");
+    let s = blinder - challenge * k;
+
+    let tracker_proof = TrackerProof { A, B, s };
+
+    serialize_tracker_proof(&tracker_proof)
 }
 
-fn deserialize_g1_point(g1_point: &G1PointBytes) -> Result<G1Affine, SerializationError> {
-    G1Affine::deserialize(Cursor::new(g1_point))
+fn unzip_trackers(trackers: &Vec<WhiskTracker>) -> (Vec<G1Affine>, Vec<G1Affine>) {
+    let vec_r: Vec<G1Affine> = trackers.iter().map(|tracker| tracker.r_G).collect();
+    let vec_s: Vec<G1Affine> = trackers.iter().map(|tracker| tracker.k_r_G).collect();
+    (vec_r, vec_s)
 }
 
-fn serialize_g1_point(g1_point: &G1Affine) -> Result<G1PointBytes, SerializationError> {
-    let mut out = [0; 48];
-    g1_point.serialize(out.as_mut_slice())?;
-    Ok(out)
-}
-
-fn deserialize_trackers(
-    trackers: &Vec<WhiskTracker>,
-) -> Result<(Vec<G1Affine>, Vec<G1Affine>), SerializationError> {
-    let vec_r: Result<Vec<G1Affine>, SerializationError> = trackers
-        .iter()
-        .map(|tracker| deserialize_g1_point(&tracker.r_g))
-        .collect();
-    let vec_s: Result<Vec<G1Affine>, SerializationError> = trackers
-        .iter()
-        .map(|tracker| deserialize_g1_point(&tracker.k_r_g))
-        .collect();
-    Ok((vec_r?, vec_s?))
-}
-
-fn serialize_trackers(
-    vec_r: &Vec<G1Affine>,
-    vec_s: &Vec<G1Affine>,
-) -> Result<Vec<WhiskTracker>, SerializationError> {
-    let trackers: Result<Vec<WhiskTracker>, SerializationError> = vec_r
+fn zip_trackers(vec_r: &Vec<G1Affine>, vec_s: &Vec<G1Affine>) -> Vec<WhiskTracker> {
+    vec_r
         .into_iter()
         .zip(vec_s.into_iter())
-        .map(|(r_g, k_r_g)| {
-            Ok(WhiskTracker {
-                r_g: serialize_g1_point(r_g)?,
-                k_r_g: serialize_g1_point(k_r_g)?,
-            })
+        .map(|(r_G, k_r_G)| WhiskTracker {
+            r_G: *r_G,
+            k_r_G: *k_r_G,
         })
-        .collect();
-    Ok(trackers?)
+        .collect()
 }
 
 fn serialize_tracker_proof(proof: &TrackerProof) -> Result<TrackerProofBytes, SerializationError> {
-    let mut out = [0u8; TRACKER_PROOF_SIZE];
+    let mut out = [0; TRACKER_PROOF_SIZE];
     proof.serialize(out.as_mut_slice())?;
     Ok(out)
 }
@@ -236,7 +242,7 @@ fn deserialize_tracker_proof(
 fn serialize_shuffle_proof(
     proof: &CurdleproofsProof,
 ) -> Result<ShuffleProofBytes, SerializationError> {
-    let mut out = [0u8; SHUFFLE_PROOF_SIZE];
+    let mut out = [0; SHUFFLE_PROOF_SIZE];
     proof.serialize(out.as_mut_slice())?;
     Ok(out)
 }
@@ -245,4 +251,264 @@ fn deserialize_shuffle_proof(
     proof_bytes: &ShuffleProofBytes,
 ) -> Result<CurdleproofsProof, SerializationError> {
     CurdleproofsProof::deserialize(Cursor::new(proof_bytes))
+}
+
+pub fn to_g1_compressed(g1: &G1Affine) -> Result<[u8; 48], SerializationError> {
+    let mut out = [0; 48];
+    g1.serialize(out.as_mut_slice())?;
+    Ok(out)
+}
+
+pub fn from_g1_compressed(buf: &[u8; 48]) -> Result<G1Affine, SerializationError> {
+    G1Affine::deserialize(Cursor::new(buf))
+}
+
+/// Returns G1 generator (x,y)
+pub fn g1_generator() -> G1Affine {
+    G1Affine::prime_subgroup_generator()
+}
+
+/// Convert bytes to a BLS field scalar. The output is not uniform over the BLS field.
+///
+/// Reads bytes in little-endian, and converts them to a field element.
+/// If the bytes are larger than the modulus, it will reduce them.
+pub fn bytes_to_bls_field(bytes: &[u8]) -> Fr {
+    Fr::from_le_bytes_mod_order(bytes)
+}
+
+/// G1 scalar multiplication
+pub fn bls_g1_scalar_multiply(g1: &G1Affine, scalar: &Fr) -> G1Affine {
+    G1Affine::from(g1.mul(*scalar))
+}
+
+/// Rand scalar
+pub fn rand_scalar<T: RngCore>(rng: &mut T) -> Fr {
+    Fr::rand(rng)
+}
+
+/// Serialize field element to bytes
+pub fn serialize_fr(fr: &Fr) -> FieldElementBytes {
+    let mut bytes = [0u8; FIELD_ELEMENT_SIZE];
+    fr.write(&mut bytes[..]).unwrap();
+    bytes
+}
+
+/// Returns field element from big endian bytes
+pub fn deserialize_fr(bytes: &[u8]) -> Fr {
+    Fr::from_be_bytes_mod_order(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::curdleproofs::generate_crs;
+    use ark_ff::PrimeField;
+    use ark_std::rand::rngs::StdRng;
+    use ark_std::rand::SeedableRng;
+    use core::iter;
+
+    fn generate_tracker<T: RngCore>(rng: &mut T, k: &Fr) -> WhiskTracker {
+        // r can be forgotten
+        let r = Fr::rand(rng);
+        let G = G1Affine::prime_subgroup_generator();
+
+        let r_G = G.mul(r);
+        let k_r_G = G1Affine::from(r_G).mul(*k);
+
+        WhiskTracker {
+            r_G: G1Affine::from(r_G),
+            k_r_G: G1Affine::from(k_r_G),
+        }
+    }
+
+    fn get_k_commitment(k: &Fr) -> G1Affine {
+        let G = G1Affine::prime_subgroup_generator();
+        G1Affine::from(G.mul(*k))
+    }
+
+    #[test]
+    fn tracker_proof() {
+        let mut rng = StdRng::seed_from_u64(0u64);
+
+        let k = Fr::rand(&mut rng);
+        let tracker = generate_tracker(&mut rng, &k);
+        let k_commitment = get_k_commitment(&k);
+
+        let tracker_proof =
+            generate_whisk_tracker_proof(&mut rng, &tracker, &k_commitment, &k).unwrap();
+        assert!(is_valid_whisk_tracker_proof(&tracker, &k_commitment, &tracker_proof).unwrap());
+    }
+
+    // Construct the CRS
+
+    struct Block {
+        pub whisk_opening_proof: TrackerProofBytes,
+        pub whisk_post_shuffle_trackers: Vec<WhiskTracker>,
+        pub whisk_shuffle_proof: ShuffleProofBytes,
+        pub whisk_shuffle_proof_m_commitment: G1Affine,
+        pub whisk_registration_proof: TrackerProofBytes,
+        pub whisk_tracker: WhiskTracker,
+        pub whisk_k_commitment: G1Affine,
+    }
+
+    struct State {
+        pub proposer_tracker: WhiskTracker,
+        pub proposer_k_commitment: G1Affine,
+        pub shuffled_trackers: Vec<WhiskTracker>,
+    }
+
+    fn process_block(crs: &CurdleproofsCrs, state: &mut State, block: &Block) {
+        let mut rng = StdRng::seed_from_u64(0u64);
+
+        // process_whisk_opening_proof
+        assert!(
+            is_valid_whisk_tracker_proof(
+                &state.proposer_tracker,
+                &state.proposer_k_commitment,
+                &block.whisk_opening_proof,
+            )
+            .unwrap(),
+            "invalid whisk_opening_proof"
+        );
+
+        // whisk_process_shuffled_trackers
+        assert!(
+            is_valid_whisk_shuffle_proof(
+                &mut rng,
+                &crs,
+                &state.shuffled_trackers,
+                &block.whisk_post_shuffle_trackers,
+                &block.whisk_shuffle_proof_m_commitment,
+                &block.whisk_shuffle_proof
+            )
+            .unwrap(),
+            "invalid whisk_shuffle_proof"
+        );
+
+        // whisk_process_tracker_registration
+        let G = G1Affine::prime_subgroup_generator();
+        if state.proposer_tracker.r_G == G {
+            // First proposal
+            assert!(
+                is_valid_whisk_tracker_proof(
+                    &block.whisk_tracker,
+                    &block.whisk_k_commitment,
+                    &block.whisk_registration_proof,
+                )
+                .unwrap(),
+                "invalid whisk_registration_proof"
+            );
+            state.proposer_tracker = block.whisk_tracker.clone();
+            state.proposer_k_commitment = block.whisk_k_commitment;
+        } else {
+            // Next proposals, registration data not used
+        }
+    }
+
+    fn produce_block(
+        crs: &CurdleproofsCrs,
+        state: &State,
+        proposer_k: &Fr,
+        proposer_index: u64,
+    ) -> Block {
+        let mut rng = StdRng::seed_from_u64(0u64);
+
+        let (whisk_post_shuffle_trackers, whisk_shuffle_proof_m_commitment, whisk_shuffle_proof) =
+            generate_whisk_shuffle_proof(&mut rng, &crs, &state.shuffled_trackers).unwrap();
+
+        let is_first_proposal = state.proposer_tracker.r_G == G1Affine::prime_subgroup_generator();
+
+        let (whisk_registration_proof, whisk_tracker, whisk_k_commitment) = if is_first_proposal {
+            // First proposal, validator creates tracker for registering
+            let whisk_tracker = generate_tracker(&mut rng, &proposer_k);
+            let whisk_k_commitment = get_k_commitment(&proposer_k);
+            let whisk_registration_proof = generate_whisk_tracker_proof(
+                &mut rng,
+                &whisk_tracker,
+                &whisk_k_commitment,
+                &proposer_k,
+            )
+            .unwrap();
+            (whisk_registration_proof, whisk_tracker, whisk_k_commitment)
+        } else {
+            // And subsequent proposals leave registration fields empty
+            let whisk_registration_proof = [0; TRACKER_PROOF_SIZE];
+            let whisk_tracker = WhiskTracker {
+                r_G: G1Affine::prime_subgroup_generator(),
+                k_r_G: G1Affine::prime_subgroup_generator(),
+            };
+            let whisk_k_commitment = G1Affine::prime_subgroup_generator();
+            (whisk_registration_proof, whisk_tracker, whisk_k_commitment)
+        };
+
+        let k_prev_proposal = if is_first_proposal {
+            // On first proposal the k is computed deterministically and known to all
+            compute_initial_k(proposer_index)
+        } else {
+            // Subsequent proposals use same k for registered tracker
+            *proposer_k
+        };
+
+        let whisk_opening_proof = generate_whisk_tracker_proof(
+            &mut rng,
+            &state.proposer_tracker,
+            &state.proposer_k_commitment,
+            &k_prev_proposal,
+        )
+        .unwrap();
+
+        Block {
+            whisk_opening_proof,
+            whisk_post_shuffle_trackers,
+            whisk_shuffle_proof,
+            whisk_shuffle_proof_m_commitment,
+            whisk_registration_proof,
+            whisk_tracker,
+            whisk_k_commitment,
+        }
+    }
+
+    fn compute_initial_k(index: u64) -> Fr {
+        Fr::from_be_bytes_mod_order(&index.to_be_bytes())
+    }
+
+    #[test]
+    fn whisk_lifecycle() {
+        let mut rng = StdRng::seed_from_u64(0u64);
+        let crs: CurdleproofsCrs = generate_crs(ELL);
+
+        // Initial tracker in state
+        let shuffled_trackers: Vec<WhiskTracker> = iter::repeat_with(|| {
+            let k = Fr::rand(&mut rng);
+            generate_tracker(&mut rng, &k)
+        })
+        .take(ELL)
+        .collect();
+
+        let proposer_index = 15400;
+        let proposer_initial_k = compute_initial_k(proposer_index);
+
+        // Initial dummy values, r = 1
+        let mut state = State {
+            proposer_tracker: WhiskTracker {
+                r_G: G1Affine::prime_subgroup_generator(),
+                k_r_G: get_k_commitment(&proposer_initial_k),
+            },
+            proposer_k_commitment: get_k_commitment(&proposer_initial_k),
+            shuffled_trackers,
+        };
+
+        // k must be kept
+        let proposer_k = Fr::rand(&mut rng);
+
+        // On first proposal, validator creates tracker for registering
+        let block_0 = produce_block(&crs, &state, &proposer_k, proposer_index);
+        // Block is valid
+        process_block(&crs, &mut state, &block_0);
+
+        // On second proposal, validator opens previously submited tracker
+        let block_1 = produce_block(&crs, &state, &proposer_k, proposer_index);
+        // Block is valid
+        process_block(&crs, &mut state, &block_1);
+    }
 }

--- a/src/whisk.rs
+++ b/src/whisk.rs
@@ -1,0 +1,248 @@
+#![allow(non_snake_case)]
+use ark_bls12_381::{Fr, G1Affine, G1Projective};
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, Read, SerializationError, Write};
+use ark_std::rand::prelude::SliceRandom;
+use ark_std::rand::RngCore;
+use ark_std::UniformRand;
+use std::io::Cursor;
+
+use crate::{
+    curdleproofs::{CurdleproofsCrs, CurdleproofsProof},
+    util::shuffle_permute_and_commit_input,
+    N_BLINDERS,
+};
+
+const G1POINT_SIZE: usize = 48;
+const SHUFFLE_PROOF_SIZE: usize = 1024;
+const TRACKER_PROOF_SIZE: usize = 1024;
+
+// TODO: Customize
+const N: usize = 64;
+const ELL: usize = N - N_BLINDERS;
+
+pub type G1PointBytes = [u8; G1POINT_SIZE];
+pub type ShuffleProofBytes = [u8; SHUFFLE_PROOF_SIZE];
+pub type TrackerProofBytes = [u8; TRACKER_PROOF_SIZE];
+
+pub struct WhiskTracker {
+    pub r_g: G1PointBytes,   // r * G
+    pub k_r_g: G1PointBytes, // k * r * G
+}
+
+/// A tracker proof object
+#[derive(Clone, Debug, CanonicalSerialize, CanonicalDeserialize)]
+pub struct TrackerProof {
+    k_G: G1Projective,
+    // TODO: Is the generator necessary to include in the proof?
+    G: G1Projective,
+    A: G1Projective,
+    B: G1Projective,
+    s: G1Projective,
+}
+
+/// Verify a whisk shuffle proof
+///
+/// # Arguments
+///
+/// * `crs`           - Curdleproofs CRS (Common Reference String), a trusted setup
+/// * `pre_trackers`  - Trackers before shuffling
+/// * `post_trackers` - Trackers after shuffling
+/// * `m`             - Commitment to secret permutation
+/// * `shuffle_proof` - Shuffle proof struct
+pub fn is_valid_whisk_shuffle_proof<T: RngCore>(
+    rng: &mut T,
+    crs: &CurdleproofsCrs,
+    pre_trackers: &Vec<WhiskTracker>,
+    post_trackers: &Vec<WhiskTracker>,
+    m: &G1PointBytes,
+    shuffle_proof: &ShuffleProofBytes,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (vec_r, vec_s) = deserialize_trackers(pre_trackers)?;
+    let (vec_t, vec_u) = deserialize_trackers(post_trackers)?;
+    let m_projective = G1Projective::from(deserialize_g1_point(m)?);
+    let shuffle_proof_instance = deserialize_shuffle_proof(shuffle_proof)?;
+
+    shuffle_proof_instance.verify(crs, &vec_r, &vec_s, &vec_t, &vec_u, &m_projective, rng)?;
+
+    Ok(())
+}
+
+/// Create a whisk shuffle proof and serialize it for Whisk
+///
+/// # Arguments
+///
+/// * `crs`          - Curdleproofs CRS (Common Reference String), a trusted setup
+/// * `pre_trackers` - Whisk trackers to shuffle
+///
+/// # Returns
+///
+/// A tuple containing
+/// * `0` `post_trackers` - Resulting shuffled trackers
+/// * `1` `m`             - Commitment to secret permutation
+/// * `2` `shuffle_proof` - Shuffle proof struct
+pub fn generate_whisk_shuffle_proof<T: RngCore>(
+    rng: &mut T,
+    crs: &CurdleproofsCrs,
+    pre_trackers: &Vec<WhiskTracker>,
+) -> Result<(Vec<WhiskTracker>, G1PointBytes, ShuffleProofBytes), Box<dyn std::error::Error>> {
+    // Get witnesses: the permutation, the randomizer, and a bunch of blinders
+    let mut permutation: Vec<u32> = (0..ELL as u32).collect();
+
+    // permutation and k (randomizer) can be forgotten immediately after creating the proof
+    permutation.shuffle(rng);
+    let k = Fr::rand(rng);
+
+    // Get shuffle inputs
+    let (vec_r, vec_s) = deserialize_trackers(pre_trackers)?;
+
+    let (vec_t, vec_u, m, vec_m_blinders) =
+        shuffle_permute_and_commit_input(crs, &vec_r, &vec_s, &permutation, &k, rng);
+
+    let shuffle_proof_instance = CurdleproofsProof::new(
+        crs,
+        vec_r.clone(),
+        vec_s.clone(),
+        vec_t.clone(),
+        vec_u.clone(),
+        m,
+        permutation.clone(),
+        k,
+        vec_m_blinders.clone(),
+        rng,
+    );
+
+    let mut shuffle_proof: Vec<u8> = vec![];
+    shuffle_proof_instance.serialize(&mut shuffle_proof)?;
+
+    Ok((
+        serialize_trackers(&vec_t, &vec_u)?,
+        serialize_g1_point(&G1Affine::from(m))?,
+        serialize_shuffle_proof(&shuffle_proof_instance)?,
+    ))
+}
+
+/// Verify knowledge of `k` such that `tracker.k_r_g == k * tracker.r_g` and `k_commitment == k * BLS_G1_GENERATOR`.
+/// Defined in https://github.com/nalinbhardwaj/curdleproofs.pie/blob/59eb1d54fe193f063a718fc3bdded4734e66bddc/curdleproofs/curdleproofs/whisk_interface.py#L48-L68
+pub fn is_valid_whisk_tracker_proof(
+    crs: &CurdleproofsCrs,
+    tracker: &WhiskTracker,
+    k_commitment: &G1PointBytes,
+    tracker_proof: &TrackerProofBytes,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let tracker_proof = deserialize_tracker_proof(tracker_proof)?;
+
+    // `k_r_G`: Existing WhiskTracker.k_r_g
+    // `r_G`: Existing WhiskTracker.k_r_g
+    // `k_G`: ?? provided externally, k commitment?
+    // `G`: Generator point, known by all not necessary
+    // `A`: From python implementation `A = multiply(G, int(blinder))`
+    // `B`: From python implementation `B = multiply(r_G, int(blinder))`
+    // `s`: From python implementation `s = blinder - challenge * k`
+
+    // challenge = transcript.get_and_append_challenge(
+    //     b"tracker_opening_proof_challenge"
+    // )
+    //
+    // Aprime = add(multiply(self.G, int(self.s)), multiply(self.k_G, int(challenge)))
+    // Bprime = add(
+    //     multiply(self.r_G, int(self.s)), multiply(self.k_r_G, int(challenge))
+    // )
+    //
+    // return eq(Aprime, self.A) and eq(Bprime, self.B)
+
+    todo!("wisk");
+}
+
+pub fn generate_whisk_tracker_proof(
+    crs: &CurdleproofsCrs,
+    tracker: &WhiskTracker,
+    k_G: G1Projective,
+    G: G1Projective,
+    k: Fr,
+) -> Result<TrackerProofBytes, Box<dyn std::error::Error>> {
+    let k_r_g = tracker.k_r_g;
+    let r_g = tracker.r_g;
+
+    // blinder = generate_blinders(1)[0]
+    // A = multiply(G, int(blinder))
+    // B = multiply(r_G, int(blinder))
+
+    // transcript.append_list(
+    //     b"tracker_opening_proof",
+    //     points_projective_to_bytes([k_G, G, k_r_G, r_G, A, B]),
+    // )
+
+    // challenge = transcript.get_and_append_challenge(
+    //     b"tracker_opening_proof_challenge"
+    // )
+    // s = blinder - challenge * k
+
+    todo!("whisk");
+}
+
+fn deserialize_g1_point(g1_point: &G1PointBytes) -> Result<G1Affine, SerializationError> {
+    G1Affine::deserialize(Cursor::new(g1_point))
+}
+
+fn serialize_g1_point(g1_point: &G1Affine) -> Result<G1PointBytes, SerializationError> {
+    let mut out = [0; 48];
+    g1_point.serialize(out.as_mut_slice())?;
+    Ok(out)
+}
+
+fn deserialize_trackers(
+    trackers: &Vec<WhiskTracker>,
+) -> Result<(Vec<G1Affine>, Vec<G1Affine>), SerializationError> {
+    let vec_r: Result<Vec<G1Affine>, SerializationError> = trackers
+        .iter()
+        .map(|tracker| deserialize_g1_point(&tracker.r_g))
+        .collect();
+    let vec_s: Result<Vec<G1Affine>, SerializationError> = trackers
+        .iter()
+        .map(|tracker| deserialize_g1_point(&tracker.k_r_g))
+        .collect();
+    Ok((vec_r?, vec_s?))
+}
+
+fn serialize_trackers(
+    vec_r: &Vec<G1Affine>,
+    vec_s: &Vec<G1Affine>,
+) -> Result<Vec<WhiskTracker>, SerializationError> {
+    let trackers: Result<Vec<WhiskTracker>, SerializationError> = vec_r
+        .into_iter()
+        .zip(vec_s.into_iter())
+        .map(|(r_g, k_r_g)| {
+            Ok(WhiskTracker {
+                r_g: serialize_g1_point(r_g)?,
+                k_r_g: serialize_g1_point(k_r_g)?,
+            })
+        })
+        .collect();
+    Ok(trackers?)
+}
+
+fn serialize_tracker_proof(proof: &TrackerProof) -> Result<TrackerProofBytes, SerializationError> {
+    let mut out = [0u8; TRACKER_PROOF_SIZE];
+    proof.serialize(out.as_mut_slice())?;
+    Ok(out)
+}
+
+fn deserialize_tracker_proof(
+    proof_bytes: &TrackerProofBytes,
+) -> Result<TrackerProof, SerializationError> {
+    TrackerProof::deserialize(Cursor::new(proof_bytes))
+}
+
+fn serialize_shuffle_proof(
+    proof: &CurdleproofsProof,
+) -> Result<ShuffleProofBytes, SerializationError> {
+    let mut out = [0u8; SHUFFLE_PROOF_SIZE];
+    proof.serialize(out.as_mut_slice())?;
+    Ok(out)
+}
+
+fn deserialize_shuffle_proof(
+    proof_bytes: &ShuffleProofBytes,
+) -> Result<CurdleproofsProof, SerializationError> {
+    CurdleproofsProof::deserialize(Cursor::new(proof_bytes))
+}


### PR DESCRIPTION
WIP: Ease integrating underlying crypto into clients that follow spec defined in https://github.com/ethereum/consensus-specs/pull/3205

- [x] `is_valid_whisk_shuffle_proof`
- [x] `generate_whisk_shuffle_proof`
- [ ] `is_valid_whisk_tracker_proof`
- [ ] `generate_whisk_tracker_proof` 