### PR TITLE
Bundle M into shuffle proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ let shuffle_proof = CurdleproofsProof::new(
 
 // Verify the shuffle proof
 assert!(shuffle_proof
-        .verify(&crs, &vec_R, &vec_S, &vec_T, &vec_U, &M, &mut rng)
+        .verify(&crs, &vec_R, &vec_S, &vec_T, &vec_U, &mut rng)
         .is_ok());
 # }
 ```

--- a/benches/perf.rs
+++ b/benches/perf.rs
@@ -112,7 +112,7 @@ fn benchmark_shuffle(c: &mut Criterion) {
     c.bench_function("verifier", |b| {
         b.iter(|| {
             assert!(shuffle_proof
-                .verify(&crs, &vec_R, &vec_S, &vec_T, &vec_U, &M, &mut rng)
+                .verify(&crs, &vec_R, &vec_S, &vec_T, &vec_U, &mut rng)
                 .is_ok());
         })
     });


### PR DESCRIPTION
From a consumer point of view, the permutation commitment and shuffle proof and produced, transported and verified together. It adds less overhead to bundle M into the shuffle proof black box for easier implementations downstream