### PR TITLE
Bundle M into ShuffleProof wrapper

### DIFF
--- a/src/whisk.rs
+++ b/src/whisk.rs
@@ -19,7 +19,7 @@ use crate::{
 
 pub const FIELD_ELEMENT_SIZE: usize = 32;
 pub const G1POINT_SIZE: usize = 48;
-pub const SHUFFLE_PROOF_SIZE: usize = 4528;
+pub const SHUFFLE_PROOF_SIZE: usize = 4528 + G1POINT_SIZE;
 // 48+48+32
 pub const TRACKER_PROOF_SIZE: usize = 128;
 
@@ -45,6 +45,13 @@ pub struct TrackerProof {
     s: Fr,
 }
 
+/// Convenience wrapper for whisk verifiers
+#[derive(Clone, Debug, CanonicalSerialize, CanonicalDeserialize)]
+pub struct ShuffleProof {
+    m: G1Projective,
+    proof: CurdleproofsProof,
+}
+
 /// Verify a whisk shuffle proof
 ///
 /// # Arguments
@@ -59,16 +66,15 @@ pub fn is_valid_whisk_shuffle_proof<T: RngCore>(
     crs: &CurdleproofsCrs,
     pre_trackers: &[WhiskTracker],
     post_trackers: &[WhiskTracker],
-    m: &G1Affine,
     shuffle_proof: &ShuffleProofBytes,
 ) -> Result<bool, SerializationError> {
     let (vec_r, vec_s) = unzip_trackers(pre_trackers);
     let (vec_t, vec_u) = unzip_trackers(post_trackers);
-    let m_projective = G1Projective::from(*m);
-    let shuffle_proof_instance = deserialize_shuffle_proof(shuffle_proof)?;
+    let shuffle_proof = deserialize_shuffle_proof(shuffle_proof)?;
 
-    Ok(shuffle_proof_instance
-        .verify(crs, &vec_r, &vec_s, &vec_t, &vec_u, &m_projective, rng)
+    Ok(shuffle_proof
+        .proof
+        .verify(crs, &vec_r, &vec_s, &vec_t, &vec_u, &shuffle_proof.m, rng)
         .is_ok())
 }
 
@@ -89,7 +95,7 @@ pub fn generate_whisk_shuffle_proof<T: RngCore>(
     rng: &mut T,
     crs: &CurdleproofsCrs,
     pre_trackers: &[WhiskTracker],
-) -> Result<(Vec<WhiskTracker>, G1Affine, ShuffleProofBytes), SerializationError> {
+) -> Result<(Vec<WhiskTracker>, ShuffleProofBytes), SerializationError> {
     // Get witnesses: the permutation, the randomizer, and a bunch of blinders
     let mut permutation: Vec<u32> = (0..ELL as u32).collect();
 
@@ -103,7 +109,7 @@ pub fn generate_whisk_shuffle_proof<T: RngCore>(
     let (vec_t, vec_u, m, vec_m_blinders) =
         shuffle_permute_and_commit_input(crs, &vec_r, &vec_s, &permutation, &k, rng);
 
-    let shuffle_proof_instance = CurdleproofsProof::new(
+    let proof = CurdleproofsProof::new(
         crs,
         vec_r.clone(),
         vec_s.clone(),
@@ -116,14 +122,10 @@ pub fn generate_whisk_shuffle_proof<T: RngCore>(
         rng,
     );
 
-    let mut shuffle_proof: Vec<u8> = vec![];
-    shuffle_proof_instance.serialize(&mut shuffle_proof)?;
+    let mut shuffle_proof_bytes = [0; SHUFFLE_PROOF_SIZE];
+    ShuffleProof { proof, m }.serialize(shuffle_proof_bytes.as_mut_slice())?;
 
-    Ok((
-        zip_trackers(&vec_t, &vec_u),
-        G1Affine::from(m),
-        serialize_shuffle_proof(&shuffle_proof_instance)?,
-    ))
+    Ok((zip_trackers(&vec_t, &vec_u), shuffle_proof_bytes))
 }
 
 /// Verify knowledge of `k` such that `tracker.k_r_g == k * tracker.r_g` and `k_commitment == k * BLS_G1_GENERATOR`.
@@ -240,18 +242,10 @@ fn deserialize_tracker_proof(
     TrackerProof::deserialize(Cursor::new(proof_bytes))
 }
 
-fn serialize_shuffle_proof(
-    proof: &CurdleproofsProof,
-) -> Result<ShuffleProofBytes, SerializationError> {
-    let mut out = [0; SHUFFLE_PROOF_SIZE];
-    proof.serialize(out.as_mut_slice())?;
-    Ok(out)
-}
-
 fn deserialize_shuffle_proof(
     proof_bytes: &ShuffleProofBytes,
-) -> Result<CurdleproofsProof, SerializationError> {
-    CurdleproofsProof::deserialize(Cursor::new(proof_bytes))
+) -> Result<ShuffleProof, SerializationError> {
+    ShuffleProof::deserialize(Cursor::new(proof_bytes))
 }
 
 pub fn to_g1_compressed(g1: &G1Affine) -> Result<[u8; 48], SerializationError> {
@@ -363,19 +357,15 @@ mod tests {
         let mut rng = StdRng::seed_from_u64(0u64);
         let crs: CurdleproofsCrs = generate_crs(ELL);
 
-        let k = Fr::rand(&mut rng);
-        let tracker = generate_tracker(&mut rng, &k);
-        let k_commitment = get_k_commitment(&k);
         let shuffled_trackers = generate_shuffle_trackers(&mut rng);
 
-        let (whisk_post_shuffle_trackers, whisk_shuffle_proof_m_commitment, whisk_shuffle_proof) =
+        let (whisk_post_shuffle_trackers, whisk_shuffle_proof) =
             generate_whisk_shuffle_proof(&mut rng, &crs, &shuffled_trackers).unwrap();
         assert!(is_valid_whisk_shuffle_proof(
             &mut rng,
             &crs,
             &shuffled_trackers,
             &whisk_post_shuffle_trackers,
-            &whisk_shuffle_proof_m_commitment,
             &whisk_shuffle_proof
         )
         .unwrap());
@@ -396,7 +386,6 @@ mod tests {
         pub whisk_opening_proof: TrackerProofBytes,
         pub whisk_post_shuffle_trackers: Vec<WhiskTracker>,
         pub whisk_shuffle_proof: ShuffleProofBytes,
-        pub whisk_shuffle_proof_m_commitment: G1Affine,
         pub whisk_registration_proof: TrackerProofBytes,
         pub whisk_tracker: WhiskTracker,
         pub whisk_k_commitment: G1Affine,
@@ -429,7 +418,6 @@ mod tests {
                 &crs,
                 &state.shuffled_trackers,
                 &block.whisk_post_shuffle_trackers,
-                &block.whisk_shuffle_proof_m_commitment,
                 &block.whisk_shuffle_proof
             )
             .unwrap(),
@@ -464,7 +452,7 @@ mod tests {
     ) -> Block {
         let mut rng = StdRng::seed_from_u64(0u64);
 
-        let (whisk_post_shuffle_trackers, whisk_shuffle_proof_m_commitment, whisk_shuffle_proof) =
+        let (whisk_post_shuffle_trackers, whisk_shuffle_proof) =
             generate_whisk_shuffle_proof(&mut rng, &crs, &state.shuffled_trackers).unwrap();
 
         let is_first_proposal = state.proposer_tracker.r_G == G1Affine::prime_subgroup_generator();
@@ -512,7 +500,6 @@ mod tests {
             whisk_opening_proof,
             whisk_post_shuffle_trackers,
             whisk_shuffle_proof,
-            whisk_shuffle_proof_m_commitment,
             whisk_registration_proof,
             whisk_tracker,
             whisk_k_commitment,


### PR DESCRIPTION
From a consumer point of view, the permutation commitment and shuffle proof and produced, transported and verified together. It adds less overhead to bundle M into the shuffle proof black box for easier implementations downstream

- Replaces https://github.com/asn-d6/curdleproofs/pull/8 by not modifying the curdleproofs API